### PR TITLE
RDKEMW-2055 : Add appId parameter to run api for

### DIFF
--- a/apis/RuntimeManager/IRuntimeManager.h
+++ b/apis/RuntimeManager/IRuntimeManager.h
@@ -80,6 +80,7 @@ struct EXTERNAL IRuntimeManager : virtual public Core::IUnknown {
 
     /** @brief Run the application */
     // @text run
+    // @param appId App identifier for the application/container
     // @param appInstanceId App identifier for the application/container
     // @param appPath path of the container/application
     // @param runtimePath(optional) run time path of the container/application
@@ -89,7 +90,7 @@ struct EXTERNAL IRuntimeManager : virtual public Core::IUnknown {
     // @param ports(optional) array of socket ports to allow
     // @param paths(optional) paths contains an additional set of files and directories to map into the container
     // @param debugSettings(optional) can include additional ports to open for gdb and other settings for debugging
-    virtual Core::hresult Run(const string& appInstanceId, const string& appPath, const string& runtimePath, IStringIterator* const& envVars, const uint32_t userId, const uint32_t groupId, IValueIterator* const& ports, IStringIterator* const& paths, IStringIterator* const& debugSettings) = 0;
+    virtual Core::hresult Run(const string& appId, const string& appInstanceId, const string& appPath, const string& runtimePath, IStringIterator* const& envVars, const uint32_t userId, const uint32_t groupId, IValueIterator* const& ports, IStringIterator* const& paths, IStringIterator* const& debugSettings) = 0;
 
     /** @brief Hibernate the application */
     // @text hibernate


### PR DESCRIPTION
StorageManager use

Reason for change : Add appId as an argument to
run method
Test Procedure: Check if appId is stored in database if passed Risks: Low
Priority: P1
Signed-off-by: Pavithra V pavviswa@synamedia.com