### PR TITLE
RDKEMW-2521: Add onDisconnected event support

### DIFF
--- a/apis/RDKWindowManager/IRDKWindowManager.h
+++ b/apis/RDKWindowManager/IRDKWindowManager.h
@@ -36,6 +36,10 @@ struct EXTERNAL IRDKWindowManager : virtual public Core::IUnknown {
     // @param minutes: notify how long user is inactive state
     virtual void OnUserInactivity(const double minutes){};
 
+    // @brief Notifies when an application is disconnected
+    // @text onDisconnected
+    // @param client: the identifier of the disconnected application
+    virtual void OnDisconnected(const std::string& client){};
   };
 
   /** Register notification interface */

--- a/apis/RDKWindowManager/IRDKWindowManager.h
+++ b/apis/RDKWindowManager/IRDKWindowManager.h
@@ -53,7 +53,7 @@ struct EXTERNAL IRDKWindowManager : virtual public Core::IUnknown {
 
   /** Allow the plugin to deinitialize to use service object */
   // @json:omit
-  virtual void Deinitialize(PluginHost::IShell* service) = 0;
+  virtual Core::hresult Deinitialize(PluginHost::IShell* service) = 0;
 
   /** Create the display window */
   // @text createDisplay


### PR DESCRIPTION
Reason for change : onDisconnect event support
in RDKWindowManager
Test Procedure: Event is dispatched when a disconnection occurs Risks: Low
Priority: P1
Signed-off-by: Pavithra V pavviswa@synamedia.com