### PR TITLE
RDKEMW-2674: RuntimeConfig object for PackageManager (#149)

### DIFF
--- a/apis/PackageManager/IAppPackageManager.h
+++ b/apis/PackageManager/IAppPackageManager.h
@@ -6,6 +6,30 @@
 
 namespace WPEFramework {
 namespace Exchange {
+#ifndef RUNTIME_CONFIG
+    struct RuntimeConfig {
+        bool dial;
+        bool wanLanAccess;
+        bool thunder;
+        int32_t systemMemoryLimit;
+        int32_t gpuMemoryLimit;
+        std::string envVars;
+        uint32_t userId;
+        uint32_t groupId;
+        uint32_t dataImageSize;
+
+        bool resourceManagerClientEnabled;
+        std::string dialId;
+        std::string command;
+        uint32_t appType;
+        std::string appPath;
+        std::string runtimePath;
+
+        std::string fireboltVersion;
+        bool enableDebugger;
+    };
+    #define RUNTIME_CONFIG
+#endif
 
     // @json 1.0.0 @text:keep
     struct EXTERNAL IPackageDownloader : virtual public Core::IUnknown {
@@ -48,7 +72,7 @@ namespace Exchange {
         virtual Core::hresult Initialize(PluginHost::IShell* service) = 0;
 
         // @json:omit
-        virtual void Deinitialize(PluginHost::IShell* service) = 0;
+        virtual Core::hresult  Deinitialize(PluginHost::IShell* service) = 0;
 
 
 	    // @brief Download
@@ -191,7 +215,7 @@ namespace Exchange {
         virtual Core::hresult Config(
             const string &packageId,
             const string &version,
-            string &config /* @out */   // XXX: JsonObject ?!
+            RuntimeConfig &configMetadata /* @out */
             ) = 0;
 
         // @brief PackageState
@@ -232,7 +256,7 @@ namespace Exchange {
             const LockReason &lockReason,
             uint32_t &lockId /* @out */,
             string &unpackedPath /* @out */,
-            string &configMetadata /* @out */,
+            RuntimeConfig &configMetadata /* @out */,
             string &appMetadata /* @out */
             // XXX: appContextPath ?!
             ) = 0;
@@ -253,7 +277,7 @@ namespace Exchange {
             const string &packageId,
             const string &version,
             string &unpackedPath /* @out */,
-            string &configMetadata /* @out */,
+            RuntimeConfig &configMetadata /* @out */,
             string &gatewayMetadataPath /* @out */,
             bool &locked /* @out */
             ) = 0;


### PR DESCRIPTION
* Addded struct RuntimeConfig

* Use struct RuntimeConfig from RuntimeConfig.h

* stubgen:include error, hard code struct

* wip

* wip

* Moved IPackageImpl.h from libpackage-sky

* use ifndef around RuntimeConfig struct

* cleanup

* Pass the plugin config to libPackage

* revert IPackageImpl.h move

* Change Deinitialize() return value