### PR TITLE
RDKEMW-4187: Missing error response string in the isClean method

### DIFF
--- a/apis/Warehouse/IWarehouse.h
+++ b/apis/Warehouse/IWarehouse.h
@@ -80,7 +80,8 @@ namespace WPEFramework
             // @param clean - out - boolean
             // @param files - out - string [] of file locations for each file
             // @param success - out - boolean
-            virtual Core::hresult IsClean(const int age, bool &clean /* @out */, IStringIterator*& files /* @out */, bool &success /* @out */) = 0;
+            // @param error -out - string
+            virtual Core::hresult IsClean(const int age, bool &clean /* @out */, IStringIterator*& files /* @out */, bool &success /* @out */, string& error /* @out */) = 0;
             
             // @text lightReset
             // @brief Resets the application data.

--- a/docs/apis/WarehousePlugin.md
+++ b/docs/apis/WarehousePlugin.md
@@ -226,6 +226,7 @@ No Events
 | result.files | array | A string [] of file locations for each file that is found that should have been deleted in the cleaning process. If the `clean` property is `true`, then this array is empty or `null` |
 | result.files[#] | string |  |
 | result.success | boolean | Whether the request succeeded |
+| result.error | string | An error message in case of a failure |
 
 ### Example
 
@@ -253,7 +254,8 @@ No Events
         "files": [
             "/opt/ctrlm.sql"
         ],
-        "success": true
+        "success": true,
+        "error": "..."
     }
 }
 ```

--- a/tools/json_generator/output/Warehouse/Warehouse.json
+++ b/tools/json_generator/output/Warehouse/Warehouse.json
@@ -104,12 +104,16 @@
                     },
                     "success":{
                         "$ref": "#/common/success"
+                    },
+                    "error":{
+                        "$ref": "#/definitions/error"
                     }
                 },
                 "required": [
                     "clean",
                     "files",
-                    "success"
+                    "success",
+                    "error"
                 ]
             }
         },


### PR DESCRIPTION
Reason for change: Added error response string in the isClean method of warehouse plugin
Test Procedure: Test isClean method
Risks: Medium
Priority: P1
Signed-off-by:Dineshkumar P dinesh_kumar2@comcast.com