### PR TITLE
RDKEMW-3964: Missing the milestones and paramList response string (#190)

### DIFF
--- a/apis/DeviceDiagnostics/IDeviceDiagnostics.h
+++ b/apis/DeviceDiagnostics/IDeviceDiagnostics.h
@@ -51,8 +51,8 @@ namespace WPEFramework
 
                 // @text onAVDecoderStatusChanged
                 // @brief Triggered when the most active status of audio/video decoder/pipeline changes
-                // @param AVDecoderStatus - in - string
-                virtual void OnAVDecoderStatusChanged(const string& AVDecoderStatus) {};
+                // @param avDecoderStatusChange - in - string
+                virtual void OnAVDecoderStatusChanged(const string& avDecoderStatusChange) {};
             };
 
             virtual Core::hresult Register(IDeviceDiagnostics::INotification* notification /* @in */) = 0;
@@ -62,17 +62,20 @@ namespace WPEFramework
             // @brief Gets the values associated with the corresponding property names
             // @param names - in - String array of property names
             // @param paramList - out - specified properties and their values
-            virtual Core::hresult GetConfiguration(IStringIterator* const& names /* @in */, IDeviceDiagnosticsParamListIterator*& paramList /* @out */) = 0;
+            // @param success - out - boolean
+            virtual Core::hresult GetConfiguration(IStringIterator* const& names /* @in */, IDeviceDiagnosticsParamListIterator*& paramList /* @out */, bool& success /* @out */) = 0;
 
             // @text getMilestones
             // @brief Returns the list of milestones
             // @param milestones - out - A string [] of milestones
-            virtual Core::hresult GetMilestones(IStringIterator*& milestones /* @out */) = 0;
+            // @param success - out - boolean
+            virtual Core::hresult GetMilestones(IStringIterator*& milestones /* @out */, bool& success /* @out */) = 0;
 
             // @text logMilestone
             // @brief Log marker string to rdk milestones log
             // @param marker - in - string
-            virtual Core::hresult LogMilestone(const string& marker /* @in */) = 0;
+            // @param success - out - boolean
+            virtual Core::hresult LogMilestone(const string& marker /* @in */, bool& success /* @out */) = 0;
 
             // @text getAVDecoderStatus
             // @brief Gets the most active status of audio/video decoder/pipeline


### PR DESCRIPTION
* RDKEMW-3964: Missing the milestones and paramList response string

Reason for change: Resolved the missing response string Test Procedure: Verify the DeviceDiagnostics Plugin APIs. Risks: Medium
Priority: P1
Signed-off-by:Dineshkumar P dinesh_kumar2@comcast.com

* RDKEMW-3964: Missing the milestones and paramList response string