### PR TITLE
RDKEMW-3890: [AI2.0][WindowManager] IRDKWindowManager - onReady, renderReady and enableDisplayRendering

### DIFF
--- a/apis/RDKWindowManager/IRDKWindowManager.h
+++ b/apis/RDKWindowManager/IRDKWindowManager.h
@@ -40,6 +40,11 @@ struct EXTERNAL IRDKWindowManager : virtual public Core::IUnknown {
     // @text onDisconnected
     // @param client: the identifier of the disconnected application
     virtual void OnDisconnected(const std::string& client){};
+
+    // @brief Posting the client for first frame ready.
+    // @text onReady
+    // @param client: notify first frame event received for client or application instance ID
+    virtual void OnReady(const string &client){};
   };
 
   /** Register notification interface */
@@ -170,6 +175,20 @@ struct EXTERNAL IRDKWindowManager : virtual public Core::IUnknown {
   // @param client: client name or application instance ID
   // @param visible: boolean indicating the visibility status: `true` for visible, `false` for hide.
   virtual Core::hresult SetVisible(const std::string &client, bool visible) = 0;
+
+  /** Get the first-frame rendered status of the application */
+  // @text renderReady
+  // @brief To get the status of first frame is rendered or not
+  // @param client: client name or application instance ID
+  // @param status: Returns true if the application has rendered first frame, false if it has not yet.
+  virtual Core::hresult RenderReady(const string& client, bool &status /* @out */) const = 0;
+
+  /** To enable/disable the rendering of a Wayland display in the window manager */
+  // @text enableDisplayRender
+  // @brief Enable or disable the rendering of a Wayland display
+  // @param client: client name or application instance ID
+  // @param enable: flag to true/false for controlling the wayland render
+  virtual Core::hresult EnableDisplayRender(const string& client, bool enable) = 0;
 
 };
 } // namespace Exchange


### PR DESCRIPTION
Reason for change : event onReady and Interface for renderReady, enableDisplayRendering method in RDKWindowManager
Test Procedure: Thunder RPC based testing of enableDisplayRendering, renderReady plugin method
Risks: Low
Priority: P1
Signed-off-by: Sundara Raja Moorthy S [subrsund@synamedia.com](mailto:subrsund@synamedia)