### PR TITLE
RDKEMW-2871 IFirmwareUpdate.h Interface header not following coding g…

### DIFF
--- a/apis/FirmwareUpdate/IFirmwareUpdate.h
+++ b/apis/FirmwareUpdate/IFirmwareUpdate.h
@@ -64,12 +64,12 @@ struct EXTERNAL IFirmwareUpdate : virtual public Core::IUnknown {
           // @param State   : State
           // @param SubState: SubState
           // @text onUpdateStateChange
-          virtual void OnUpdateStateChange (const State state  , const SubState substate )= 0;
+          virtual void OnUpdateStateChange (const State state  , const SubState substate ) {};
 
           // @brief This notification is raised between flashing started state and flashing succeeded/failed.
           // @param percentageComplete   : Number between 0 and 100 indicating the "percentage complete" of the flashing process. 
           // @text onFlashingStateChange
-          virtual void OnFlashingStateChange (const uint32_t percentageComplete )= 0;
+          virtual void OnFlashingStateChange (const uint32_t percentageComplete ) {};
   
    };
 


### PR DESCRIPTION
…uidelines

Reason for change: Solve the guideline issues on IFirmwareUpdate.h
Test Procedure: verify build success and basic test
Risks: Low
Priority: P1
Signed-off-by: ramkumar_prabaharan@comcast.com