### PR TITLE
RDKEMW-2653 ISystemMode.h Interface header not following coding guide…

### DIFF
--- a/apis/SystemMode/IDeviceOptimizeStateActivator.h
+++ b/apis/SystemMode/IDeviceOptimizeStateActivator.h
@@ -30,7 +30,7 @@ namespace Exchange {
 
         /// Requests the component to asynchronously transition to the new state.
         /// @param[in] newState     The new target state to transition to.
-        virtual void Request(const string&  newState  /* @in @text newState*/) {};
+        virtual Core::hresult Request(const string&  newState  /* @in @text newState*/) = 0;
     };
 }
 }

--- a/apis/SystemMode/IDeviceOptimizeStateActivator.h
+++ b/apis/SystemMode/IDeviceOptimizeStateActivator.h
@@ -30,7 +30,7 @@ namespace Exchange {
 
         /// Requests the component to asynchronously transition to the new state.
         /// @param[in] newState     The new target state to transition to.
-        virtual void Request(const string&  newState  /* @in @text newState*/) = 0;
+        virtual void Request(const string&  newState  /* @in @text newState*/) {};
     };
 }
 }

--- a/apis/SystemMode/ISystemMode.h
+++ b/apis/SystemMode/ISystemMode.h
@@ -62,14 +62,14 @@ struct EXTERNAL ISystemMode : virtual public Core::IUnknown {
   // @param[in] callsign       callsign of client.
   // @param[in] systemMode       The system mode.
   // @returns uint32_t
-  virtual uint32_t ClientActivated(const string& callsign /* @in @text callsign*/ ,const string& systemMode) = 0;
+  virtual Core::hresult ClientActivated(const string& callsign /* @in @text callsign*/ ,const string& systemMode) = 0;
 
   // @text clientDeactivated
   // @brief To put client plugin entry in map.
   // @param[in] callsign       callsign of client.
   // @param[in] systemMode       The system mode.
   // @returns uint32_t
-  virtual uint32_t ClientDeactivated(const string& callsign /* @in @text callsign*/, const string& systemMode) = 0;
+  virtual Core::hresult ClientDeactivated(const string& callsign /* @in @text callsign*/, const string& systemMode) = 0;
 };
 } // namespace Exchange
 } // namespace WPEFramework

--- a/apis/SystemMode/ISystemMode.h
+++ b/apis/SystemMode/ISystemMode.h
@@ -61,14 +61,14 @@ struct EXTERNAL ISystemMode : virtual public Core::IUnknown {
   // @brief To put client plugin entry in map.
   // @param[in] callsign       callsign of client.
   // @param[in] systemMode       The system mode.
-  // @returns uint32_t
+  // @returns Core::hresult
   virtual Core::hresult ClientActivated(const string& callsign /* @in @text callsign*/ ,const string& systemMode) = 0;
 
   // @text clientDeactivated
   // @brief To put client plugin entry in map.
   // @param[in] callsign       callsign of client.
   // @param[in] systemMode       The system mode.
-  // @returns uint32_t
+  // @returns Core::hresult
   virtual Core::hresult ClientDeactivated(const string& callsign /* @in @text callsign*/, const string& systemMode) = 0;
 };
 } // namespace Exchange


### PR DESCRIPTION
…lines

Reason for change: Solve the guideline issues on ISystemMode.h
Test Procedure: verify build success and basic test
Risks: Low
Priority: P1
Signed-off-by: ramkumar_prabaharan@comcast.com