### PR TITLE
RDKEMW-2653 ISystemMode.h Interface header not following coding guide

### DIFF
--- a/apis/AppManager/IAppManager.h
+++ b/apis/AppManager/IAppManager.h
@@ -28,18 +28,23 @@ struct EXTERNAL IAppManager : virtual public Core::IUnknown {
   enum { ID = ID_APPMANAGER };
 
   enum AppLifecycleState : uint8_t {
-          APP_STATE_UNKNOWN     = 0   /* @text APP_STATE_UNKNOWN */,
-          APP_STATE_RUNNING     = 1   /* @text APP_STATE_RUNNING */,
-          APP_STATE_ACTIVE      = 2   /* @text APP_STATE_ACTIVE */,
-          APP_STATE_SUSPENDED   = 3   /* @text APP_STATE_SUSPENDED */,
-          APP_STATE_HIBERNATED  = 4   /* @text APP_STATE_HIBERNATED */,
-          APP_STATE_TERMINATED  = 5   /* @text APP_STATE_TERMINATED */
+          APP_STATE_UNKNOWN      = 0   /* @text APP_STATE_UNKNOWN */,
+          APP_STATE_UNLOADED     = 1   /* @text APP_STATE_UNLOADED */,
+          APP_STATE_LOADING      = 2   /* @text APP_STATE_LOADING */,
+          APP_STATE_INITIALIZING = 3   /* @text APP_STATE_INITIALIZING */,
+          APP_STATE_PAUSED       = 4   /* @text APP_STATE_PAUSED */,
+          APP_STATE_RUNNING      = 5   /* @text APP_STATE_RUNNING */,
+          APP_STATE_ACTIVE       = 6   /* @text APP_STATE_ACTIVE */,
+          APP_STATE_SUSPENDED    = 7   /* @text APP_STATE_SUSPENDED */,
+          APP_STATE_HIBERNATED   = 8   /* @text APP_STATE_HIBERNATED */,
+          APP_STATE_TERMINATED   = 9   /* @text APP_STATE_TERMINATED */
       };
 
   enum AppErrorReason : uint8_t {
-          APP_ERROR_UNKNOWN          = 0     /* @text APP_ERROR_UNKNOWN */,
-          APP_ERROR_STATE_TIMEOUT    = 1     /* @text APP_ERROR_STATE_TIMEOUT */,
-          APP_ERROR_ABORT            = 2     /* @text APP_ERROR_ABORT */
+          APP_ERROR_NONE             = 0     /* @text APP_ERROR_NONE */,
+          APP_ERROR_UNKNOWN          = 1     /* @text APP_ERROR_UNKNOWN */,
+          APP_ERROR_STATE_TIMEOUT    = 2     /* @text APP_ERROR_STATE_TIMEOUT */,
+          APP_ERROR_ABORT            = 3     /* @text APP_ERROR_ABORT */
       };
 
   // @event 

--- a/apis/AppManager/IAppManager.h
+++ b/apis/AppManager/IAppManager.h
@@ -28,23 +28,18 @@ struct EXTERNAL IAppManager : virtual public Core::IUnknown {
   enum { ID = ID_APPMANAGER };
 
   enum AppLifecycleState : uint8_t {
-          APP_STATE_UNKNOWN      = 0   /* @text APP_STATE_UNKNOWN */,
-          APP_STATE_UNLOADED     = 1   /* @text APP_STATE_UNLOADED */,
-          APP_STATE_LOADING      = 2   /* @text APP_STATE_LOADING */,
-          APP_STATE_INITIALIZING = 3   /* @text APP_STATE_INITIALIZING */,
-          APP_STATE_PAUSED       = 4   /* @text APP_STATE_PAUSED */,
-          APP_STATE_RUNNING      = 5   /* @text APP_STATE_RUNNING */,
-          APP_STATE_ACTIVE       = 6   /* @text APP_STATE_ACTIVE */,
-          APP_STATE_SUSPENDED    = 7   /* @text APP_STATE_SUSPENDED */,
-          APP_STATE_HIBERNATED   = 8   /* @text APP_STATE_HIBERNATED */,
-          APP_STATE_TERMINATED   = 9   /* @text APP_STATE_TERMINATED */
+          APP_STATE_UNKNOWN     = 0   /* @text APP_STATE_UNKNOWN */,
+          APP_STATE_RUNNING     = 1   /* @text APP_STATE_RUNNING */,
+          APP_STATE_ACTIVE      = 2   /* @text APP_STATE_ACTIVE */,
+          APP_STATE_SUSPENDED   = 3   /* @text APP_STATE_SUSPENDED */,
+          APP_STATE_HIBERNATED  = 4   /* @text APP_STATE_HIBERNATED */,
+          APP_STATE_TERMINATED  = 5   /* @text APP_STATE_TERMINATED */
       };
 
   enum AppErrorReason : uint8_t {
-          APP_ERROR_NONE             = 0     /* @text APP_ERROR_NONE */,
-          APP_ERROR_UNKNOWN          = 1     /* @text APP_ERROR_UNKNOWN */,
-          APP_ERROR_STATE_TIMEOUT    = 2     /* @text APP_ERROR_STATE_TIMEOUT */,
-          APP_ERROR_ABORT            = 3     /* @text APP_ERROR_ABORT */
+          APP_ERROR_UNKNOWN          = 0     /* @text APP_ERROR_UNKNOWN */,
+          APP_ERROR_STATE_TIMEOUT    = 1     /* @text APP_ERROR_STATE_TIMEOUT */,
+          APP_ERROR_ABORT            = 2     /* @text APP_ERROR_ABORT */
       };
 
   // @event 


### PR DESCRIPTION
Reason for change: Solve the guideline issues on ISystemMode.h
Test Procedure: verify build success and basic test
Risks: Low
Priority: P1
Signed-off-by: [ramkumar_prabaharan@comcast.com](mailto:ramkumar_prabaharan@comcast.com)