### PR TITLE
RDKEMW-3813: [AI2.0][RDKWindowManager] Add setVisible thunder interface

### DIFF
--- a/apis/RDKWindowManager/IRDKWindowManager.h
+++ b/apis/RDKWindowManager/IRDKWindowManager.h
@@ -169,6 +169,13 @@ struct EXTERNAL IRDKWindowManager : virtual public Core::IUnknown {
   // @param client/appInstanceId: Client/Application instance ID as a plain string (e.g., "rdkwmtestapp_13193")
   virtual Core::hresult SetFocus(const string &client) = 0;
 
+  /** Sets the visibility of the given client or appInstanceId */
+  // @text setVisible
+  // @brief Sets the visibility of the given client or appInstanceId
+  // @param client: client name or application instance ID
+  // @param visible: boolean indicating the visibility status: `true` for visible, `false` for hide.
+  virtual Core::hresult SetVisible(const std::string &client, bool visible) = 0;
+
   /** Get the first-frame rendered status of the application */
   // @text renderReady
   // @brief To get the status of first frame is rendered or not


### PR DESCRIPTION
Reason for change : Interface for setVisible method in RDKWindowManager
Test Procedure: Thunder RPC based testing of setVisible plugin method
Risks: Low
Priority: P1
Signed-off-by: Arularasan Namachivayam [anamachi@synamedia.com](mailto:anamachi@synamedia)