### PR TITLE
RDKEMW-5316: To list AV1 codec from PlayerInfo

### DIFF
--- a/apis/PlayerInfo/IPlayerInfo.h
+++ b/apis/PlayerInfo/IPlayerInfo.h
@@ -56,7 +56,8 @@ namespace Exchange {
             VIDEO_MPEG4,
             VIDEO_VP8,
             VIDEO_VP9,
-            VIDEO_VP10
+            VIDEO_VP10,
+            VIDEO_AV1
         };
 
         enum PlaybackResolution : uint8_t {

--- a/apis/PlayerInfo/PlayerInfo.json
+++ b/apis/PlayerInfo/PlayerInfo.json
@@ -51,7 +51,8 @@
         "MPEG",
         "VP8",
         "VP9",
-        "VP10"
+        "VP10",
+        "AV1"
       ],
       "enumvalues": [
         0,
@@ -62,7 +63,8 @@
         5,
         6,
         7,
-        8
+        8,
+        9
       ],
       "description": "Video Codec supported by the platform",
       "example": "VideoH264"


### PR DESCRIPTION
Reason For Change: PlayerInfo service doesn't report AV1 codec though platform supports
Test procedure: Mentioned in the ticket RDKTV-35827
Risks: Low
Signed-off-by: vidhathri.joshi@gmail.com