### PR TITLE
RDKEMW-5139: [RDKM-VA-Devices]EntServices : DeviceInfo.modelid, DeviceInfo.make and DeviceInfo.socname APIs return ERROR_GENERAL response.

### DIFF
--- a/apis/DeviceInfo/DeviceInfo.json
+++ b/apis/DeviceInfo/DeviceInfo.json
@@ -134,32 +134,6 @@
       "description": "Device type",
       "example": "IpStb"
     },
-    "make": {
-      "type": "string",
-      "enum": [
-        "manufacturer1",
-	"RaspberryPi4"
-      ],
-      "description": "Device manufacturer",
-      "example": "alphanumerical string"
-    },
-    "sku": {
-      "type": "string",
-      "enum": [
-        "SKU1",
-	"RPI4"
-      ],
-      "description": "Device model number or SKU",
-      "example": "alphanumerical string"
-    },
-    "socname": {
-      "type": "string",
-      "enum": [
-        "SOC1"
-      ],
-      "description": "SOC Name",
-      "example": "alphanumerical string"
-    },
     "yocto": {
       "type": "string",
       "enum": [
@@ -453,7 +427,8 @@
         "type": "object",
         "properties": {
           "sku": {
-            "$ref": "#/definitions/sku"
+            "type": "string",
+            "example": "alphanumerical string"
           }
         },
         "required": [
@@ -474,7 +449,8 @@
         "type": "object",
         "properties": {
           "make": {
-            "$ref": "#/definitions/make"
+            "type": "string",
+            "example": "alphanumerical string"
           }
         },
         "required": [
@@ -560,7 +536,8 @@
         "type": "object",
         "properties": {
           "socname": {
-            "$ref": "#/definitions/socname"
+            "type": "string",
+            "example": "alphanumerical string"
           }
         },
         "required": [


### PR DESCRIPTION
**Reason for change:** Changed the DeviceInfo.modelid, DeviceInfo.make and DeviceInfo.socname API response datatype as string.
**Test Procedure:** Build and verify
**Risks:** High.
**Signed-off-by:** sundaramuneeswaran_muthuraj@comcast.com