### PR TITLE
RDKEMW-3266: Remove unused/duplicate parameters

### DIFF
--- a/apis/LifecycleManager/ILifecycleManager.h
+++ b/apis/LifecycleManager/ILifecycleManager.h
@@ -105,7 +105,7 @@ struct EXTERNAL ILifecycleManager : virtual public Core::IUnknown {
     // @json:omit
     // @text spawnApp
     // @brief Perform launching of application with window and runtime manager
-    virtual Core::hresult SpawnApp(const string& appId /* @in */, const string& appPath /* @in */, const string& appConfig /* @in */, const string& runtimeAppId /* @in */, const string& runtimePath /* @in */, const string& runtimeConfig /* @in */, const string& launchIntent /* @in */, const string& environmentVars /* @in */, const bool enableDebugger /* @in */, const LifecycleState targetLifecycleState /* @in */, const RuntimeConfig& runtimeConfigObject /* @in */, const string& launchArgs /* @in */, string& appInstanceId /* @out */, string& errorReason /* @out */, bool& success /* @out */) = 0;
+    virtual Core::hresult SpawnApp(const string& appId /* @in */, const string& launchIntent /* @in */, const LifecycleState targetLifecycleState /* @in */, const RuntimeConfig& runtimeConfigObject /* @in */, const string& launchArgs /* @in */, string& appInstanceId /* @out */, string& errorReason /* @out */, bool& success /* @out */) = 0;
 
     /** Get the list of loaded applications */
     // @json:omit

--- a/apis/RuntimeManager/IRuntimeManager.h
+++ b/apis/RuntimeManager/IRuntimeManager.h
@@ -115,15 +115,12 @@ struct EXTERNAL IRuntimeManager : virtual public Core::IUnknown {
     // @text run
     // @param appId App identifier for the application/container
     // @param appInstanceId App identifier for the application/container
-    // @param appPath path of the container/application
-    // @param runtimePath(optional) run time path of the container/application
-    // @param envVars The tokens from the Firebolt Gateway will be passed as part of the environmentVars
     // @param userId userId used to identify the user
     // @param userId groupid used to represent a group
     // @param ports(optional) array of socket ports to allow
     // @param paths(optional) paths contains an additional set of files and directories to map into the container
     // @param debugSettings(optional) can include additional ports to open for gdb and other settings for debugging
-    virtual Core::hresult Run(const string& appId, const string& appInstanceId, const string& appPath, const string& runtimePath, IStringIterator* const& envVars, const uint32_t userId, const uint32_t groupId, IValueIterator* const& ports, IStringIterator* const& paths, IStringIterator* const& debugSettings, const RuntimeConfig& runtimeConfigObject) = 0;
+    virtual Core::hresult Run(const string& appId, const string& appInstanceId, const uint32_t userId, const uint32_t groupId, IValueIterator* const& ports, IStringIterator* const& paths, IStringIterator* const& debugSettings, const RuntimeConfig& runtimeConfigObject) = 0;
 
     /** @brief Hibernate the application */
     // @text hibernate


### PR DESCRIPTION
Reason for change : Remove unused/duplicate parameters from launch/preload api's flow
Test Procedure: preload, launch and terminate sequence tested
Risks: Medium
Priority: P1
Signed-off-by: Dali Hariharan bp-dharih957@cable.comcast.com