### PR TITLE
RDKEMW-5551 Fix getInstalledApps response having escape characters

### DIFF
--- a/apis/AppManager/IAppManager.h
+++ b/apis/AppManager/IAppManager.h
@@ -128,7 +128,7 @@ struct EXTERNAL IAppManager : virtual public Core::IUnknown {
   // @text getInstalledApps
   // @brief Function fetches the details of all applications currently installed
   // @param apps A list containing the details of installed applications.
-  virtual Core::hresult GetInstalledApps(string& apps /* @out */) = 0;
+  virtual Core::hresult GetInstalledApps(string& apps /* @out @opaque */) = 0;
 
   /** Check the specific application is installed on the system. **/
   // @text isInstalled


### PR DESCRIPTION
Reason for change : Added @opaque tag in interface method to avoid adding escape characters
Test Procedure: Run AppManager L1 test in github workflow and test in full stack
Risks: Medium
Priority: P1
Signed-off-by: Siva Thandayuthapani [sithanda@synamedia.com](mailto:sithanda@synamedia.com)