### PR TITLE
RDKEMW-6226: Update the IMessageControl.h header file

### DIFF
--- a/apis/MessageControl/IMessageControl.h
+++ b/apis/MessageControl/IMessageControl.h
@@ -58,6 +58,7 @@ struct EXTERNAL IMessageControl : virtual public Core::IUnknown {
 
     // @property
     // @brief Retrieves a list of current message controls
+    // Test1
     virtual uint32_t Controls(IControlIterator*& control /* @out */) const = 0;
   };
 


### PR DESCRIPTION
Reason for change: Interface header must follow the interface header RDKE coding guidelines
Test Procedure: please referred ticket descriptions Risks: Medium
Priority: P1