### PR TITLE
RDKEMW-6566: Change display-offset param to 64-bit

### DIFF
--- a/apis/TextTrack/ITextTrack.h
+++ b/apis/TextTrack/ITextTrack.h
@@ -431,7 +431,7 @@ struct EXTERNAL ITextTrack : virtual public Core::IUnknown {
      * @param data Is the data to display, properly formatted as per the expectations of the type used
      * @text sendSessionData
      */
-    virtual Core::hresult SendSessionData(const uint32_t sessionId, const DataType type, const int32_t displayOffsetMs, const string &data) = 0;
+    virtual Core::hresult SendSessionData(const uint32_t sessionId, const DataType type, const int64_t displayOffsetMs, const string &data) = 0;
     /**
      * @brief Sends the current timestamp from a media player to a render session.
      * @details The STC is used in some forms of text rendering to compare against the text data PTS to determine its presentation time.


### PR DESCRIPTION
The change is necessary because a 32-bit offset is not always enough. The underlying libraries can easily handle 64-bit, but unfortunately this interface was created with 32-bit.
We have control of both clients that use this function, and the change is desired by one and unused by the other, so we believe it's safe.