### PR TITLE
RDKEMW-7761 Move Telemetry related APIs to the Telemetry plugin

### DIFF
--- a/apis/Telemetry/ITelemetry.h
+++ b/apis/Telemetry/ITelemetry.h
@@ -89,7 +89,7 @@ namespace WPEFramework
             // @brief Checks the telemetry opt-out status.
             // @param OptOut  - out - boolean
             // @param success - out - boolean
-            virtual Core::hresult IsOptOutTelemetry(bool& optOut /* @out @text Opt-Out*/, bool& success /* @out */) = 0
+            virtual Core::hresult IsOptOutTelemetry(bool& optOut /* @out @text Opt-Out*/, bool& success /* @out */) = 0;
             /**********************isOptOutTelemetry() - end*****************************************/
         };
     } // namespace Exchange

--- a/apis/Telemetry/ITelemetry.h
+++ b/apis/Telemetry/ITelemetry.h
@@ -81,7 +81,7 @@ namespace WPEFramework
             // @brief Sets the telemetry opt-out status.
             // @param OptOut  - in - boolean
             // @param  - out - struct
-            virtual Core::hresult SetOptOutTelemetry(const bool optOut /* @text Opt-Out */, & successResult /* @out */) = 0;
+            virtual Core::hresult SetOptOutTelemetry(const bool optOut /* @text Opt-Out */, TelemetrySuccess& successResult /* @out */) = 0;
             /**********************setOptOutTelemetry() - end*****************************************/
 
             /**********************isOptOutTelemetry() - start***************************************/

--- a/apis/Telemetry/ITelemetry.h
+++ b/apis/Telemetry/ITelemetry.h
@@ -42,14 +42,14 @@ namespace WPEFramework
                 virtual void OnReportUpload(const string& telemetryUploadStatus) {};
             };
 
-            virtual Core::hresult Register(ITelemetry::INotification* notification /* @in */) = 0;
-            virtual Core::hresult Unregister(ITelemetry::INotification* notification /* @in */) = 0;
+            virtual Core::hresult Register(ITelemetry::INotification* notification) = 0;
+            virtual Core::hresult Unregister(ITelemetry::INotification* notification) = 0;
 
             /**********************setReportProfileStatus() - start****************************/
             // @text setReportProfileStatus
             // @brief Sets the status of telemetry reporting
             // @param status - in - string
-            virtual Core::hresult SetReportProfileStatus(const string& status /* @in */) = 0;
+            virtual Core::hresult SetReportProfileStatus(const string& status) = 0;
             /**********************setReportProfileStatus() - end******************************/
 
             /**********************logApplicationEvent() - start*******************************/
@@ -57,7 +57,7 @@ namespace WPEFramework
             // @brief Logs an application
             // @param eventName - in - string
             // @param eventValue - in - string
-            virtual Core::hresult LogApplicationEvent(const string& eventName /* @in */, const string& eventValue /* @in */) = 0;
+            virtual Core::hresult LogApplicationEvent(const string& eventName , const string& eventValue) = 0;
             /**********************logApplicationEvent() - end*********************************/
 
             /**********************uploadReport() - start**************************************/
@@ -71,6 +71,22 @@ namespace WPEFramework
             // @brief Abort report upload
             virtual Core::hresult AbortReport() = 0;
             /**********************abortReport() - end*****************************************/
+
+            /**********************setOptOutTelemetry() - start***************************************/
+            // @text setOptOutTelemetry
+            // @brief Sets the telemetry opt-out status.
+            // @param OptOut  - in - boolean
+            // @param TelemetrySuccess - out - struct
+            virtual Core::hresult SetOptOutTelemetry(const bool OptOut /* @text Opt-Out */, TelemetrySuccess& successResult /* @out */) = 0;
+            /**********************setOptOutTelemetry() - end*****************************************/
+
+            /**********************isOptOutTelemetry() - start***************************************/
+	        // @text isOptOutTelemetry
+            // @brief Checks the telemetry opt-out status.
+            // @param OptOut  - out - boolean
+            // @param success - out - boolean
+            virtual Core::hresult IsOptOutTelemetry(bool& OptOut /* @out @text Opt-Out*/, bool& success /* @out */) = 0
+            /**********************isOptOutTelemetry() - end*****************************************/
         };
     } // namespace Exchange
 } // namespace WPEFramework

--- a/apis/Telemetry/ITelemetry.h
+++ b/apis/Telemetry/ITelemetry.h
@@ -31,6 +31,10 @@ namespace WPEFramework
         {
             enum { ID = ID_TELEMETRY };
 
+            struct EXTERNAL TelemetrySuccess {
+                bool success;
+            };
+
             // @event
             struct EXTERNAL INotification : virtual public Core::IUnknown 
             {
@@ -76,8 +80,8 @@ namespace WPEFramework
             // @text setOptOutTelemetry
             // @brief Sets the telemetry opt-out status.
             // @param OptOut  - in - boolean
-            // @param TelemetrySuccess - out - struct
-            virtual Core::hresult SetOptOutTelemetry(const bool OptOut /* @text Opt-Out */, TelemetrySuccess& successResult /* @out */) = 0;
+            // @param  - out - struct
+            virtual Core::hresult SetOptOutTelemetry(const bool optOut /* @text Opt-Out */, & successResult /* @out */) = 0;
             /**********************setOptOutTelemetry() - end*****************************************/
 
             /**********************isOptOutTelemetry() - start***************************************/
@@ -85,7 +89,7 @@ namespace WPEFramework
             // @brief Checks the telemetry opt-out status.
             // @param OptOut  - out - boolean
             // @param success - out - boolean
-            virtual Core::hresult IsOptOutTelemetry(bool& OptOut /* @out @text Opt-Out*/, bool& success /* @out */) = 0
+            virtual Core::hresult IsOptOutTelemetry(bool& optOut /* @out @text Opt-Out*/, bool& success /* @out */) = 0
             /**********************isOptOutTelemetry() - end*****************************************/
         };
     } // namespace Exchange


### PR DESCRIPTION
Reason for change: Moved Telemetry related APIs from systemservices plugin to the Telemetry plugin.
Test Procedure: Test Telemetry - SetOptOutTelemetry and IsOptOutTelemetry APIs
Risks: Low
Priority: P2
Version: Minor
Signed-off-by:Dineshkumar P dinesh_kumar2@comcast.com