### PR TITLE
RDKEMW-8150 : Move Firmware related APIs from SystemServices plugin to FirmwareUpdate Plugin

### DIFF
--- a/apis/FirmwareUpdate/IFirmwareUpdate.h
+++ b/apis/FirmwareUpdate/IFirmwareUpdate.h
@@ -92,8 +92,8 @@ struct EXTERNAL IFirmwareUpdate : virtual public Core::IUnknown {
   // @brief Enable or disable the AutoReboot feature.
   // @param[in] enable Boolean to enable or disable AutoReboot
   // @returns Core::hresult
-  // @text setFirmwareAutoReboot
-  virtual Core::hresult SetFirmwareAutoReboot(const bool enable, Result& result /* @out */) = 0;
+  // @text setAutoReboot
+  virtual Core::hresult SetAutoReboot(const bool enable, Result& result /* @out */) = 0;
 
 };
 } // namespace Exchange


### PR DESCRIPTION
Reason for change: Moved Firmware related APIs from System plugin to FirmwareUpdate
Test Procedure: Test - SetAutoReboot API
Risks: Low
Priority: P2
Version: Minor
Signed-off-by:Dineshkumar P [dinesh_kumar2@comcast.com]