### PR TITLE
RDKEMW-8619 : Multiple issues on FrameRate plugin.

### DIFF
--- a/docs/apis/FrameRatePlugin.md
+++ b/docs/apis/FrameRatePlugin.md
@@ -21,7 +21,7 @@ A org.rdk.FrameRate plugin for Thunder framework.
 # Description
 
 The `FrameRate` plugin allows you to collect FPS data. 
-Framerate plugin is specific to TV devices not supported on STB devices as per HAL implementation.
+NOTE: The Framerate plugin is supported only on TV devices and its not compatible on STB devices, as per HAL implementation.
 
 The plugin is designed to be loaded and executed within the Thunder framework. For more information about the framework refer to [[Thunder](#Thunder)].
 


### PR DESCRIPTION
Update Framerate plugin documentation as the plugin supports TV devices.