### PR TITLE
RDKEMW-16812 : [EntOS] [A4K] Mute Fails During YouTube Playback with Apple TV via HDMI (CEC FeatureAbort: CEC Version)

### DIFF
--- a/apis/HdmiCecSink/IHdmiCecSink.h
+++ b/apis/HdmiCecSink/IHdmiCecSink.h
@@ -161,6 +161,16 @@
                 // @param powerStatus: Power status of the device
                 virtual void ReportAudioDevicePowerStatus(const int powerStatus) {};
 
+                // @brief Notifies when a key release CEC message is received from other CEC device
+                // @text onKeyReleaseEvent
+                // @param logicalAddress: Logical address of the device
+                virtual void OnKeyReleaseEvent(const int logicalAddress) {};
+
+                // @brief Notifies when a key press CEC message is received from other CEC device
+                // @text onKeyPressEvent
+                // @param logicalAddress: Logical address of the device
+                // @param keyCode: Key code of the key press event
+                virtual void OnKeyPressEvent(const int logicalAddress, const int keyCode) {};
 
             };
 


### PR DESCRIPTION
RDKEMW-16812 : [EntOS] [A4K] Mute Fails During YouTube Playback with Apple TV via HDMI (CEC FeatureAbort: CEC Version)

Add OnKeyPressEvent and OnKeyReleaseEvent for HdmiCecSink