### PR TITLE
RDKEMW-16778: ENT Service API for retrieving previous reboot info

### DIFF
--- a/apis/DeviceDiagnostics/IDeviceDiagnostics.h
+++ b/apis/DeviceDiagnostics/IDeviceDiagnostics.h
@@ -48,7 +48,7 @@ namespace WPEFramework
                 string reason /* @text reason */;
                 string customReason /* @text customReason */; 
                 string otherReason /* @text otherReason */;
-                string lastHardPowerReset /* @text lastHardPowerReset */;
+                string lastHardPowerReset /* @text lastHardPowerReset @default:"unknown" */;
             };
 
             using IDeviceDiagnosticsParamListIterator = RPC::IIteratorType<ParamList, ID_DEVICE_DIAGNOSTICS_PARAM_LIST_ITERATOR>;

--- a/docs/apis/DeviceDiagnostics.md
+++ b/docs/apis/DeviceDiagnostics.md
@@ -237,7 +237,7 @@ This method takes no parameters.
 | result.rebootInfo.reason | string | reason |
 | result.rebootInfo.customReason | string | customReason |
 | result.rebootInfo.otherReason | string | otherReason |
-| result.rebootInfo.lastHardPowerReset | string | lastHardPowerReset |
+| result.rebootInfo.lastHardPowerReset @default:"unknown" | string | lastHardPowerReset |
 | result.success | bool | boolean |
 
 ### Examples
@@ -274,7 +274,7 @@ curl -H 'content-type:text/plain;' --data-binary '{"jsonrpc": 2.0, "id": 3, "met
             "reason": "",
             "customReason": "",
             "otherReason": "",
-            "lastHardPowerReset": ""
+            "lastHardPowerReset @default:\"unknown\"": ""
         },
         "success": true
     }


### PR DESCRIPTION
Reason for change: ENT Service API for retrieving previous reboot info
Test Procedure: check the ticket
Risks: Medium
Priority: P1
version: Patch