### PR TITLE
RDKEMW-19882: Add ITextTrack functions for preview sessions

### DIFF
--- a/.github/instructions/docs_apis.instructions.md
+++ b/.github/instructions/docs_apis.instructions.md
@@ -1,0 +1,9 @@
+---
+applyTo: "docs/apis/**/*.md"
+---
+
+## Documentation files
+
+These files are auto-generated. Do not perform review on these files.
+
+Exception: When the documentation generator or its invocation is changed, the generated files must be checked for correct generation.

--- a/apis/Ids.h
+++ b/apis/Ids.h
@@ -180,6 +180,7 @@ namespace Exchange {
         ID_TEXT_TRACK_TTML_STYLE                     = ID_TEXT_TRACK + 3,
         ID_TEXT_TRACK_TTML_STYLE_NOTIFICATION        = ID_TEXT_TRACK + 4,
         ID_TEXT_TRACK_CAPABILITIES                   = ID_TEXT_TRACK + 5,
+        ID_TEXT_TRACK_SESSION_INFO_ITERATOR          = ID_TEXT_TRACK + 6,
 
 	ID_USB_DEVICE                                = ID_ENTOS_OFFSET + 0x1A0,
 	ID_USB_PRODUCT_INFO_ITERATOR                 = ID_USB_DEVICE + 1,
@@ -226,7 +227,7 @@ namespace Exchange {
 
         //Reserved for L2 test plugin
 	ID_L2TEST_CONTROLLER                         = ID_ENTOS_OFFSET + 0x270,
-      
+
         ID_SYSTEMSERVICES                            = ID_ENTOS_OFFSET + 0x280,
         ID_SYSTEMSERVICES_WAKEUPSOURCES_ITERATOR     = ID_SYSTEMSERVICES + 1,
         ID_SYSTEMSERVICES_NOTIFICATION               = ID_SYSTEMSERVICES + 2,

--- a/apis/TextTrack/ITextTrack.h
+++ b/apis/TextTrack/ITextTrack.h
@@ -22,7 +22,7 @@
 #include "Module.h"
 // @stubgen:include <com/IIteratorType.h>
 
-#define ITEXTTRACK_VERSION 4
+#define ITEXTTRACK_VERSION 5
 
 namespace WPEFramework {
 namespace Exchange {
@@ -314,7 +314,7 @@ struct EXTERNAL ITextTrackClosedCaptionsStyle : virtual public Core::IUnknown {
 /* @json 1.0.0 @text:keep */
 struct EXTERNAL ITextTrackTtmlStyle : virtual public Core::IUnknown {
     enum {
-	    ID = ID_TEXT_TRACK_TTML_STYLE
+        ID = ID_TEXT_TRACK_TTML_STYLE
     };
 
     /* @event */
@@ -354,7 +354,6 @@ struct EXTERNAL ITextTrackTtmlStyle : virtual public Core::IUnknown {
      * @text getTtmlStyleOverrides
      */
     virtual Core::hresult GetTtmlStyleOverrides(string& style /* @out */) const = 0;
-
 };
 
 /*
@@ -394,7 +393,7 @@ struct EXTERNAL ITextTrackCapabilities : virtual public Core::IUnknown {
 /*
     This is the COM-RPC interface for handling TextTrack sessions.
 */
-/* @json 1.4.0 @text:keep */
+/* @json 1.5.0 @text:keep */
 struct EXTERNAL ITextTrack : virtual public Core::IUnknown {
     enum {
         ID = ID_TEXT_TRACK
@@ -407,6 +406,30 @@ struct EXTERNAL ITextTrack : virtual public Core::IUnknown {
         WEBVTT = 3
     };
 
+    enum class SubtitleFormat : uint8_t {
+        NONE = 0,
+        TTML = 1,
+        CC = 2,
+        WEBVTT = 3,
+        TELETEXT = 4, // USES PES DATA
+        DVBSUB = 5,   // USES PES DATA
+        SCTE = 6      // USES PES DATA
+    };
+
+    // Structured information about a session, returned by GetSessions().
+    struct EXTERNAL SessionInfo {
+        uint32_t sessionId; /* @brief The session ID */
+        string whoAmI; /* @brief An identifier for the caller that created the session */
+        string displayHandle; /* @brief The display handle of the session */
+        SubtitleFormat format; /* @brief The type of the session (CC, TTML, etc). Can be NONE if not yet set. */
+        bool isPreview; /* @brief Whether the session is a preview session or not */
+        bool isMuted; /* @brief Whether the session is currently muted or not */
+        bool isPaused; /* @brief Whether the session is currently paused or not */
+        uint64_t dataCount; /* @brief The number of data packets sent to this session, for debugging purposes. The count is the number of times SendSessionData() has been called. */
+        string info; /* @brief Opaque debug information about the session */
+    };
+    using ISessionInfoIterator = RPC::IIteratorType<SessionInfo, ID_TEXT_TRACK_SESSION_INFO_ITERATOR>;
+
     // Sessions
     /**
      * @brief Opens a new renderSession.
@@ -415,9 +438,10 @@ struct EXTERNAL ITextTrack : virtual public Core::IUnknown {
      * of the "selection" functions to select a session type, and UnMuteSession() to get subtitles displayed.
      * @param displayHandle is an encoding of the wayland display name
      * @param sessionId On success the returned session id ex: 1
+     * @param whoAmI Optional identifier for the caller. If set it will be remembered and returned in GetSessions().
      * @text openSession
      */
-    virtual Core::hresult OpenSession(const string &displayHandle, uint32_t &sessionId /* @out */) = 0;
+    virtual Core::hresult OpenSession(const string &displayHandle, uint32_t &sessionId /* @out */, const string &whoAmI /* @optional @default:"" */ = {}) = 0;
     /**
      * @brief Closes a previously opened render session.
      * @details Any created windows and surfaces is destroyed
@@ -464,7 +488,7 @@ struct EXTERNAL ITextTrack : virtual public Core::IUnknown {
      * @brief Sends data of Closed Captions, Captions or Timed Text data to a render session.
      * @param sessionId Is the session
      * @param type Is the type of data
-     * @param displayOffsetMs Is currently unused
+     * @param displayOffsetMs Is added to a timestamp in the data to determine when to display it. The offset is in milliseconds and can be negative. Not all types support this.
      * @param data Is the data to display, properly formatted as per the expectations of the type used
      * @text sendSessionData
      */
@@ -492,9 +516,10 @@ struct EXTERNAL ITextTrack : virtual public Core::IUnknown {
     /**
      * @brief Sets a static text in the display for preview purposes.
      * @details The session must be opened as usual and a type chosen. The text will only be shown if the type of session supports preview.
+     * @param sessionId Is the session
      * @param text Is the text to display
-     * @returns Core::ERROR_OK if preview is shown
-     * @returns Core::ERROR_NOT_SUPPORTED if preview is not supported
+     * @retval Core::ERROR_NONE if preview is shown
+     * @retval Core::ERROR_NOT_SUPPORTED if preview is not supported
      * @text setPreviewText
      */
     virtual Core::hresult SetPreviewText(const uint32_t sessionId, const string &text) = 0;
@@ -572,22 +597,139 @@ struct EXTERNAL ITextTrack : virtual public Core::IUnknown {
      * @param sessionId is the session
      * @param handle is a textual representation of the video decoder handle
      * @text associateVideoDecoder
-     * @returns ERROR_NOT_SUPPORTED if the function is not implemented
-     * @returns ERROR_GENERAL if the association failed (whether bad handle is used or lack of support on the platform).
-     * @returns ERROR_OK on success
+     * @retval Core::ERROR_NOT_SUPPORTED if the function is not implemented
+     * @retval Core::ERROR_GENERAL if the association failed (whether bad handle is used or lack of support on the platform).
+     * @retval Core::ERROR_NONE on success
      */
     virtual Core::hresult AssociateVideoDecoder(const uint32_t sessionId, const string &handle) { return Core::ERROR_NOT_SUPPORTED; }
 
     // @brief Return the interface version implemented
     // @details This allows to query the running plugin for the version of the interface
     // it was compiled to support. This information can be helpful in determining whether
-    // a certain functionality can be expected to be present.
+    // a certain functionality can be expected to be present. There is no guarantee that the plugin has implemented
+    // all functions of that version.
     // Added in version 4
     // @param version will receive the version number ex: 4
     // @text getInterfaceVersion
     // @retval Core::ERROR_NOT_SUPPORTED if the function is not implemented
-    // @retval Core::ERROR_OK on success
+    // @retval Core::ERROR_NONE on success
     virtual Core::hresult GetInterfaceVersion(uint32_t& version /* @out */) const { return Core::ERROR_NOT_SUPPORTED; }
+
+    /**
+     * @brief Creates a new rendering session.
+     * @details The session is newly opened, the session type is not set and display is muted. Use one
+     * of the "selection" functions to select a session type, and UnMuteSession() to get subtitles displayed.
+     * In contrast to OpenSession(), this function will not return an existing session if the displayHandle is
+     * already in use, but will always create a new session. This allows multiple sessions to be created for
+     * the same displayHandle, which can be useful for example for preview purposes.
+     * Added in version 5
+     * @text createSession
+     * @param displayHandle is an encoding of the wayland display name
+     * @param whoAmI identifier for the caller; must not be empty.
+     * @param sessionId On success the returned session id ex: 1
+     * @retval Core::ERROR_NOT_SUPPORTED if the function is not implemented
+     * @retval Core::ERROR_GENERAL if we were unable to create the session
+     * @retval Core::ERROR_NONE on success
+     */
+    virtual Core::hresult CreateSession(const string &displayHandle, const string &whoAmI, uint32_t &sessionId /* @out */) { return Core::ERROR_NOT_SUPPORTED; }
+
+    /**
+     * @brief Get a list of active sessions.
+     * Added in version 5
+     * @text getSessions
+     * @param sessions On success, will contain an iterator to the list of active sessions (see SessionInfo struct)
+     * @retval Core::ERROR_NOT_SUPPORTED if the function is not implemented
+     * @retval Core::ERROR_NONE on success
+     */
+    virtual Core::hresult GetSessions(ISessionInfoIterator *&sessions /* @out */) const { return Core::ERROR_NOT_SUPPORTED; }
+
+    /**
+     * @brief Create a preview session for purposes of previewing style settings.
+     * @details Like CreateSession(), except: the preview session will be created as a CC type session and unmuted.
+     * There can only be one active preview session.
+     * Creating a preview session will cause all other sessions to be muted automatically until the preview session is closed.
+     * Use ApplyCustomClosedCaptionsStyleToSession() to preview style changes.
+     * Given a blank displayHandle, we will create a preview session on the standard display (from the configuration file).
+     * Use SetPreviewText() to set the text to display in the preview session.
+     * Use SetPreviewGeometry() to set the position of the preview session.
+     * Added in version 5
+     * @text createPreviewSession
+     * @param displayHandle is an encoding of the wayland display name
+     * @param whoAmI identifier for the caller; must not be empty.
+     * @param sessionId On success the returned session id ex: 1
+     * @retval Core::ERROR_NOT_SUPPORTED if the function is not implemented
+     * @retval Core::ERROR_GENERAL if we were unable to create the session
+     * @retval Core::ERROR_NONE on success
+     */
+    virtual Core::hresult CreatePreviewSession(const string &displayHandle, const string &whoAmI, uint32_t &sessionId /* @out */) { return Core::ERROR_NOT_SUPPORTED; }
+
+    enum class Anchor : uint8_t {
+        CENTER = 0,
+        TOP = 1,
+        BOTTOM = 2,
+        LEFT = 3,
+        RIGHT = 4,
+        TOP_LEFT = 5,
+        TOP_RIGHT = 6,
+        BOTTOM_LEFT = 7,
+        BOTTOM_RIGHT = 8
+    };
+
+    /**
+     * @brief Set the position of the preview session.
+     * @details The positions are given as percentage of the subtitle drawing area, so 0.5 means centre and 0.0 means top or left, 1.0 is bottom or right.
+     * The anchor value indicates which point of the text the positions refer to, so for example if the anchor is TOP_LEFT, the text will be positioned
+     * in such a way that the top left of the text is at the given position. If the anchor is CENTER, the text will be centered on
+     * the given position. This allows for more flexible positioning of the preview text.
+     * The default geometry is centred on the display/drawing area (0.5, 0.5, Anchor::CENTER).
+     * Added in version 5
+     * @text setPreviewGeometry
+     * @param sessionId is the session
+     * @param xPos is the horizontal position (0..1) for the preview text
+     * @param yPos is the vertical position (0..1) for the preview text
+     * @param anchor indicates the anchor point of the preview text, i.e. which point of the text the positions refer to.
+     * @retval Core::ERROR_NOT_SUPPORTED if the function is not implemented
+     * @retval Core::ERROR_GENERAL if the geometry could not be set
+     * @retval Core::ERROR_NONE on success
+     */
+    virtual Core::hresult SetPreviewGeometry(const uint32_t sessionId, const float xPos /* @restrict:0.0..1.0 */, const float yPos /* @restrict:0.0..1.0 */, const Anchor anchor) { return Core::ERROR_NOT_SUPPORTED; }
+
+    using ISubtitleFormatIterator = RPC::IIteratorType<SubtitleFormat, RPC::ID_VALUEITERATOR>;
+
+    /**
+     * @brief Sets whether the global ClosedCaptionsStyle applies to a given session type.
+     * @details When set to true, the global ClosedCaptionsStyle will be converted and applied to all sessions of the given type. The conversion
+     * will be done according to the best effort conversion rules for the given type. When set to false, the global ClosedCaptionsStyle will not be applied.
+     * Added in version 5
+     * @text setClosedCaptionsStyleAppliesTo
+     * @param format The session type to configure
+     * @param applies If true, the global ClosedCaptionsStyle applies to sessions of this type
+     * @retval Core::ERROR_NOT_SUPPORTED if the function is not implemented
+     * @retval Core::ERROR_GENERAL if the session type is not supported
+     * @retval Core::ERROR_NONE on success
+     */
+    virtual Core::hresult SetClosedCaptionsStyleAppliesTo(SubtitleFormat format, const bool applies) { return Core::ERROR_NOT_SUPPORTED; }
+
+    /**
+     * @brief Gets whether the global ClosedCaptionsStyle applies to a given session type.
+     * @details Added in version 5
+     * @text getClosedCaptionsStyleAppliesTo
+     * @param format The session type to query
+     * @param applies On success, true if the global ClosedCaptionsStyle applies to sessions of this type
+     * @retval Core::ERROR_NOT_SUPPORTED if the function is not implemented
+     * @retval Core::ERROR_NONE on success
+     */
+    virtual Core::hresult GetClosedCaptionsStyleAppliesTo(SubtitleFormat format, bool &applies /* @out */) const { return Core::ERROR_NOT_SUPPORTED; }
+
+    /**
+     * @brief Gets the list of session types for which the global ClosedCaptionsStyle applies.
+     * @details Added in version 5
+     * @text getClosedCaptionsStyleAppliesToList
+     * @param iterator On success, an iterator over the session types for which the global ClosedCaptionsStyle applies
+     * @retval Core::ERROR_NOT_SUPPORTED if the function is not implemented
+     * @retval Core::ERROR_NONE on success
+     */
+    virtual Core::hresult GetClosedCaptionsStyleAppliesToList(ISubtitleFormatIterator *&iterator /* @out */) const { return Core::ERROR_NOT_SUPPORTED; }
 };
 
 } // namespace Exchange

--- a/docs/apis/TextTrack.md
+++ b/docs/apis/TextTrack.md
@@ -2,7 +2,7 @@
 <a id="TextTrack_Module"></a>
 # TextTrack Module
 
-**Version: [1.4.0](https://github.com/rdkcentral/entservices-apis/tree/main/apis/TextTrack/ITextTrack.h)**
+**Version: [1.5.0](https://github.com/rdkcentral/entservices-apis/tree/main/apis/TextTrack/ITextTrack.h)**
 
 A TextTrack module for Thunder framework.
 
@@ -1957,6 +1957,7 @@ None
 | :-------- | :-------- | :-------- |
 | params | object |  |
 | params.displayHandle | string | is an encoding of the wayland display name |
+| params.whoAmI | string | Optional identifier for the caller. If set it will be remembered and returned in GetSessions(). |
 ### Results
 | Name | Type | Description |
 | :-------- | :-------- | :-------- |
@@ -1974,7 +1975,8 @@ None
     "id": 2,
     "method": "org.rdk.TextTrack.openSession",
     "params": {
-        "displayHandle": ""
+        "displayHandle": "",
+        "whoAmI": ""
     }
 }
 ```
@@ -1983,7 +1985,7 @@ None
 #### CURL Command
 
 ```curl
-curl -H 'content-type:text/plain;' --data-binary '{"jsonrpc": 2.0, "id": 2, "method": "org.rdk.TextTrack.openSession", "params": {"displayHandle": ""}}' http://127.0.0.1:9998/jsonrpc
+curl -H 'content-type:text/plain;' --data-binary '{"jsonrpc": 2.0, "id": 2, "method": "org.rdk.TextTrack.openSession", "params": {"displayHandle": "", "whoAmI": ""}}' http://127.0.0.1:9998/jsonrpc
 ```
 
 
@@ -2165,7 +2167,7 @@ None
 | params | object |  |
 | params.sessionId | integer | Is the session |
 | params.type | string | Is the type of data. Possible values: PES, TTML, CC, WEBVTT |
-| params.displayOffsetMs | integer | Is currently unused |
+| params.displayOffsetMs | integer | Is added to a timestamp in the data to determine when to display it. The offset is in milliseconds and can be negative. Not all types support this. |
 | params.data | string | Is the data to display, properly formatted as per the expectations of the type used |
 ### Results
 | Name | Type | Description |
@@ -2273,7 +2275,7 @@ None
 | Name | Type | Description |
 | :-------- | :-------- | :-------- |
 | params | object |  |
-| params.sessionId | integer | On success the returned session id  |
+| params.sessionId | integer | Is the session |
 | params.text | string | Is the text to display |
 ### Results
 | Name | Type | Description |
@@ -2312,6 +2314,20 @@ curl -H 'content-type:text/plain;' --data-binary '{"jsonrpc": 2.0, "id": 8, "met
     "jsonrpc": 2.0,
     "id": 8,
     "result": null
+}
+```
+
+
+#### Error Response (Core::ERROR_NOT_SUPPORTED)
+
+```json
+{
+    "jsonrpc": 2.0,
+    "id": 8,
+    "error": {
+        "code": 22,
+        "message": "if preview is not supported"
+    }
 }
 ```
 


### PR DESCRIPTION
Main change is adding the CreatePreviewSession and SetPreviewGeometry
functions, with CreateSession and GetSessions coming along for a fuller
experience.
Also added functions to control automatic application of CC styling to
other formats, subject to support.
Bumping ITEXTTRACK_VERSION to 5.