### PR TITLE
RDKEMW-17434: OCDM Interface for robustnesslevel

### DIFF
--- a/apis/OpenCDMi/IDRM.h
+++ b/apis/OpenCDMi/IDRM.h
@@ -524,7 +524,7 @@ struct IGoogleCastAuthExtension {
 
 struct IRobustnessExtension {
     virtual ~IRobustnessExtension() = default;
-    virtual CDMi_RESULT GetSupportedRobustness(std::list<std::string>& levels) const = 0;
+    virtual CDMi_RESULT GetSupportedRobustness(std::list<std::string>& levels /* @out */) const = 0;
 };
 
 struct ISystemFactory {

--- a/apis/OpenCDMi/IDRM.h
+++ b/apis/OpenCDMi/IDRM.h
@@ -45,6 +45,7 @@
 #include <string>
 #include <type_traits>
 #include <typeinfo>
+#include <list>
 #include <vector>
 
 #include <interfaces/Portability.h>
@@ -519,6 +520,11 @@ struct IGoogleCastAuthExtension {
     virtual CDMi_RESULT GenDeviceKeyAndCert(std::string& wrappedDeviceKey /* @out */, std::string& deviceCertificate /* @out */) = 0;
     virtual CDMi_RESULT GetModelCertChain(std::string& certChain /* @out */) const = 0;
     virtual CDMi_RESULT GetSystemId(uint32_t& id /* @out */) const = 0;
+};
+
+struct IRobustnessExtension {
+    virtual ~IRobustnessExtension() = default;
+    virtual CDMi_RESULT GetSupportedRobustness(std::list<std::string>& levels) const = 0;
 };
 
 struct ISystemFactory {

--- a/apis/OpenCDMi/IOCDM.h
+++ b/apis/OpenCDMi/IOCDM.h
@@ -198,6 +198,11 @@ struct IAccessorOCDM : virtual public Core::IUnknown {
         uint8_t buffer[] /* @out @length:bufferSize */) const
         = 0;
 
+    // Get the Robustness levels from DRM
+    virtual OCDM_RESULT GetSupportedRobustness(
+        const std::string& keySystem,
+        RPC::IStringIterator*& robustness /* @out */) const = 0;
+
     // Create a MediaKeySession using the supplied init data and CDM data.
     virtual OCDM_RESULT
     CreateSession(const string& keySystem, const int32_t licenseType,


### PR DESCRIPTION
Reason for change: Implement a interfaces in webkit to query the robustness level from CDM
Test Procedure: Check the Widevine L1 DRM support on Glass/Stream with the test URL and regression tsting of webapps
Priority: P1
Risks: None